### PR TITLE
Accounts.tm > Support scopes for client credentials 

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -282,7 +282,8 @@ function useRefreshTokenGrant (done) {
 function useClientCredentialsGrant (done) {
   // Client credentials
   var clientId = this.client.clientId,
-    clientSecret = this.client.clientSecret;
+    clientSecret = this.client.clientSecret,
+    requestBody = this.req.body;
 
   if (!clientId || !clientSecret) {
     return done(error('invalid_client',
@@ -290,7 +291,7 @@ function useClientCredentialsGrant (done) {
   }
 
   var self = this;
-  return this.model.getUserFromClient(clientId, clientSecret,
+  return this.model.getUserFromClient(clientId, clientSecret, requestBody,
       function (err, user) {
     if (err) return done(error('server_error', false, err));
     if (!user) {

--- a/test/grant.client_credentials.js
+++ b/test/grant.client_credentials.js
@@ -51,9 +51,11 @@ describe('Granting with client_credentials grant type', function () {
         grantTypeAllowed: function (clientId, grantType, callback) {
           callback(false, true);
         },
-        getUserFromClient: function (clientId, clientSecret, callback) {
+        getUserFromClient: function (clientId, clientSecret, requestBody, callback) {
           clientId.should.equal('thom');
           clientSecret.should.equal('nightworld');
+          requestBody.should.have.property('scopes');
+          requestBody.scopes.should.equal('test1 test2');
           callback(false, false); // Fake invalid user
         }
       },
@@ -64,7 +66,8 @@ describe('Granting with client_credentials grant type', function () {
       .post('/oauth/token')
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send({
-        grant_type: 'client_credentials'
+        grant_type: 'client_credentials',
+        scopes: 'test1 test2'
       })
       .set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
       .expect(400, /client credentials are invalid/i, done);


### PR DESCRIPTION
#### Changes:
- Pass request body to getUserFromClient so that scopes can be derived from requested scopes

#### References:
- YouTrack [Dev-2238](https://freedom.myjetbrains.com/youtrack/issue/Dev-2238)

#### Tests:
- Setup with npm i
- Run `npm test` in master branch, note the errors/number of errors
- [ ] Run `npm test` in this PR's branch, no new errors should occur and it should not show any error for the ff test case:
```
Granting with client_credentials grant type should detect invalid user
```